### PR TITLE
feat: criar portal de alertas de remessas em layout dark

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# Portal de Alertas - Remessas
+
+Portal web estático para monitoramento de contratos e alertas de remessas, com layout escuro inspirado no modelo enviado.
+
+## Funcionalidades
+
+- Carregamento de dados por arquivo CSV/JSON.
+- Botão de demonstração com dados prontos.
+- Filtros por ano, mês e intervalo de data.
+- Cards de resumo com níveis de urgência.
+- Gráfico de evolução mensal de remessas.
+- Tabela detalhada com paginação.
+
+## Formato esperado do CSV
+
+```csv
+cnpj,cliente,contrato,nomeObra,volume,ultimaRemessa
+12.345.678/0001-10,Cliente X,C-1001,Obra Y,15,2026-01-12
+```
+
+## Rodar localmente
+
+Como é um site estático, basta abrir o arquivo `index.html` no navegador.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Portal de Alertas - Remessas</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <main class="container">
+      <header class="topbar">
+        <div>
+          <h1>Portal de Alertas - Remessas</h1>
+          <p>Acompanhamento de contratos e alertas de remessas.</p>
+        </div>
+        <button class="btn btn-outline">Sair</button>
+      </header>
+
+      <section class="panel controls-panel">
+        <div class="controls-row">
+          <input type="file" id="fileInput" accept=".csv,.json" />
+          <button id="uploadBtn" class="btn btn-primary">Carregar arquivo</button>
+          <button id="demoBtn" class="btn btn-secondary">Carregar demo</button>
+          <button id="clearBtn" class="btn btn-danger">Excluir dados</button>
+        </div>
+        <p id="statusText">Nenhum arquivo selecionado</p>
+
+        <div class="filters">
+          <select id="yearFilter"></select>
+          <select id="monthFilter"></select>
+          <input type="date" id="startDate" />
+          <input type="date" id="endDate" />
+        </div>
+      </section>
+
+      <section class="panel">
+        <h2>Resumo</h2>
+        <div class="summary-grid top">
+          <article class="card"><strong id="contractsCount">0</strong><span>Contratos exibidos</span></article>
+          <article class="card"><strong id="clientsCount">0</strong><span>Clientes únicos (CNPJ)</span></article>
+          <article class="card"><strong id="volumeCount">0</strong><span>Volume total da obra</span></article>
+        </div>
+        <div class="summary-grid bottom">
+          <article class="card status ok"><h3>OK</h3><strong id="okCount">0</strong><span>0 a 7 dias sem remessa</span></article>
+          <article class="card status warn"><h3>Atenção</h3><strong id="warnCount">0</strong><span>8 a 14 dias sem remessa</span></article>
+          <article class="card status alert"><h3>Atenção grave</h3><strong id="alertCount">0</strong><span>15 a 21 dias sem remessa</span></article>
+          <article class="card status critical"><h3>Plano de ação</h3><strong id="criticalCount">0</strong><span>&gt; 21 dias sem remessa</span></article>
+        </div>
+      </section>
+
+      <section class="panel">
+        <div class="panel-header">
+          <h2>Evolução de remessas</h2>
+          <button id="refreshChart" class="btn btn-outline">Atualizar gráfico</button>
+        </div>
+        <div id="chart" class="chart"></div>
+      </section>
+
+      <section class="panel">
+        <div class="panel-header">
+          <h2>Detalhamento</h2>
+          <div>
+            <button id="prevPage" class="btn btn-outline">Anterior</button>
+            <button id="nextPage" class="btn btn-outline">Próxima</button>
+          </div>
+        </div>
+        <p id="tableMeta"></p>
+        <div class="table-wrap">
+          <table>
+            <thead>
+              <tr>
+                <th>CNPJ / Cliente</th>
+                <th>Contrato</th>
+                <th>Nome da obra</th>
+                <th>Volume da obra</th>
+                <th>Última remessa</th>
+                <th>Dias sem remessa</th>
+                <th>Status</th>
+              </tr>
+            </thead>
+            <tbody id="tableBody"></tbody>
+          </table>
+        </div>
+      </section>
+    </main>
+
+    <script src="script.js"></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,220 @@
+const state = {
+  data: [],
+  filtered: [],
+  page: 1,
+  pageSize: 8,
+};
+
+const demoData = [
+  { cnpj: "12.345.678/0001-10", cliente: "Cliente Construtora Delta", contrato: "C-1003", nomeObra: "Condomínio Horizonte", volume: 20, ultimaRemessa: "2026-01-02" },
+  { cnpj: "23.456.789/0001-11", cliente: "Cliente Pedra Forte", contrato: "C-1002", nomeObra: "Edifício Atlântico", volume: 7, ultimaRemessa: "2026-01-07" },
+  { cnpj: "34.567.890/0001-12", cliente: "Cliente Areia Azul", contrato: "C-1001", nomeObra: "Residencial Aquarela", volume: 12, ultimaRemessa: "2026-01-11" },
+];
+
+const el = {
+  fileInput: document.getElementById("fileInput"),
+  uploadBtn: document.getElementById("uploadBtn"),
+  demoBtn: document.getElementById("demoBtn"),
+  clearBtn: document.getElementById("clearBtn"),
+  yearFilter: document.getElementById("yearFilter"),
+  monthFilter: document.getElementById("monthFilter"),
+  startDate: document.getElementById("startDate"),
+  endDate: document.getElementById("endDate"),
+  statusText: document.getElementById("statusText"),
+  chart: document.getElementById("chart"),
+  tableBody: document.getElementById("tableBody"),
+  tableMeta: document.getElementById("tableMeta"),
+};
+
+function daysWithoutShipment(date) {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const last = new Date(date);
+  last.setHours(0, 0, 0, 0);
+  return Math.max(0, Math.round((today - last) / 86400000));
+}
+
+function statusFromDays(days) {
+  if (days <= 7) return "ok";
+  if (days <= 14) return "warn";
+  if (days <= 21) return "alert";
+  return "critical";
+}
+
+function statusLabel(status) {
+  return {
+    ok: "OK",
+    warn: "Atenção",
+    alert: "Atenção grave",
+    critical: "Plano de ação",
+  }[status];
+}
+
+function monthKey(dateString) {
+  const d = new Date(dateString);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}`;
+}
+
+function updateFilters() {
+  const years = [...new Set(state.data.map((item) => new Date(item.ultimaRemessa).getFullYear()))].sort();
+  el.yearFilter.innerHTML = `<option value="all">Ano: todos</option>${years.map((y) => `<option value="${y}">${y}</option>`).join("")}`;
+
+  const months = [...Array(12)].map((_, index) => ({ value: index + 1, label: `Mês ${index + 1}` }));
+  el.monthFilter.innerHTML = `<option value="all">Mês: todos</option>${months.map((m) => `<option value="${m.value}">${m.label}</option>`).join("")}`;
+}
+
+function applyFilters() {
+  const year = el.yearFilter.value;
+  const month = el.monthFilter.value;
+  const start = el.startDate.value ? new Date(el.startDate.value) : null;
+  const end = el.endDate.value ? new Date(el.endDate.value) : null;
+
+  state.filtered = state.data.filter((item) => {
+    const d = new Date(item.ultimaRemessa);
+    if (year !== "all" && d.getFullYear() !== Number(year)) return false;
+    if (month !== "all" && d.getMonth() + 1 !== Number(month)) return false;
+    if (start && d < start) return false;
+    if (end && d > end) return false;
+    return true;
+  });
+
+  state.filtered.sort((a, b) => daysWithoutShipment(b.ultimaRemessa) - daysWithoutShipment(a.ultimaRemessa));
+  state.page = 1;
+  renderAll();
+}
+
+function setText(id, value) {
+  document.getElementById(id).textContent = value;
+}
+
+function renderSummary() {
+  const uniqueClients = new Set(state.filtered.map((item) => item.cnpj)).size;
+  const volumeTotal = state.filtered.reduce((sum, item) => sum + Number(item.volume || 0), 0);
+
+  const counters = { ok: 0, warn: 0, alert: 0, critical: 0 };
+  state.filtered.forEach((item) => counters[statusFromDays(daysWithoutShipment(item.ultimaRemessa))]++);
+
+  setText("contractsCount", state.filtered.length);
+  setText("clientsCount", uniqueClients);
+  setText("volumeCount", volumeTotal);
+  setText("okCount", counters.ok);
+  setText("warnCount", counters.warn);
+  setText("alertCount", counters.alert);
+  setText("criticalCount", counters.critical);
+}
+
+function renderChart() {
+  const byMonth = {};
+  state.filtered.forEach((item) => {
+    const key = monthKey(item.ultimaRemessa);
+    byMonth[key] = (byMonth[key] || 0) + 1;
+  });
+
+  const entries = Object.entries(byMonth).sort(([a], [b]) => a.localeCompare(b));
+  const maxValue = Math.max(1, ...entries.map(([, v]) => v));
+
+  if (entries.length === 0) {
+    el.chart.innerHTML = "<p>Sem dados para exibir no gráfico.</p>";
+    return;
+  }
+
+  el.chart.innerHTML = entries
+    .map(([month, value]) => {
+      const h = 70 + (value / maxValue) * 160;
+      return `<div class="bar"><div class="bar-inner" style="height:${h}px"></div><small>${value}</small><label>${month}</label></div>`;
+    })
+    .join("");
+}
+
+function renderTable() {
+  const startIndex = (state.page - 1) * state.pageSize;
+  const pageData = state.filtered.slice(startIndex, startIndex + state.pageSize);
+
+  el.tableBody.innerHTML = pageData
+    .map((item) => {
+      const days = daysWithoutShipment(item.ultimaRemessa);
+      const status = statusFromDays(days);
+      const months = (days / 30).toFixed(1);
+      return `<tr>
+        <td>${item.cnpj}<br>${item.cliente}</td>
+        <td>${item.contrato}</td>
+        <td>${item.nomeObra || "-"}</td>
+        <td>${item.volume}</td>
+        <td>${new Date(item.ultimaRemessa).toLocaleDateString("pt-BR")}</td>
+        <td>${days} dias (${months} meses)</td>
+        <td><span class="badge ${status}">${statusLabel(status)}</span></td>
+      </tr>`;
+    })
+    .join("");
+
+  const totalPages = Math.max(1, Math.ceil(state.filtered.length / state.pageSize));
+  el.tableMeta.textContent = `Ordenado da maior para a menor urgência (dias sem remessa). Mostrando ${pageData.length} de ${state.filtered.length} registros • Página ${state.page}/${totalPages}`;
+}
+
+function renderAll() {
+  renderSummary();
+  renderChart();
+  renderTable();
+}
+
+function parseCsv(text) {
+  const [head, ...lines] = text.trim().split(/\r?\n/);
+  const keys = head.split(",").map((k) => k.trim());
+  return lines.map((line) => {
+    const values = line.split(",").map((v) => v.trim());
+    const obj = {};
+    keys.forEach((k, i) => (obj[k] = values[i]));
+    return {
+      ...obj,
+      volume: Number(obj.volume || 0),
+      ultimaRemessa: obj.ultimaRemessa,
+    };
+  });
+}
+
+el.demoBtn.addEventListener("click", () => {
+  state.data = [...demoData];
+  updateFilters();
+  applyFilters();
+  el.statusText.textContent = `Demo carregada com sucesso (${state.data.length} registros).`;
+});
+
+el.uploadBtn.addEventListener("click", async () => {
+  const file = el.fileInput.files[0];
+  if (!file) {
+    el.statusText.textContent = "Selecione um arquivo primeiro.";
+    return;
+  }
+
+  const content = await file.text();
+  state.data = file.name.endsWith(".json") ? JSON.parse(content) : parseCsv(content);
+  updateFilters();
+  applyFilters();
+  el.statusText.textContent = `Arquivo carregado com sucesso (${state.data.length} registros).`;
+});
+
+el.clearBtn.addEventListener("click", () => {
+  state.data = [];
+  state.filtered = [];
+  state.page = 1;
+  updateFilters();
+  renderAll();
+  el.statusText.textContent = "Dados limpos.";
+});
+
+[el.yearFilter, el.monthFilter, el.startDate, el.endDate].forEach((item) => item.addEventListener("change", applyFilters));
+document.getElementById("refreshChart").addEventListener("click", renderChart);
+
+document.getElementById("prevPage").addEventListener("click", () => {
+  state.page = Math.max(1, state.page - 1);
+  renderTable();
+});
+
+document.getElementById("nextPage").addEventListener("click", () => {
+  const totalPages = Math.max(1, Math.ceil(state.filtered.length / state.pageSize));
+  state.page = Math.min(totalPages, state.page + 1);
+  renderTable();
+});
+
+updateFilters();
+renderAll();

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,162 @@
+:root {
+  --bg: #020c2f;
+  --panel: #081b53;
+  --stroke: #0f67d8;
+  --text: #d5e6ff;
+  --muted: #87a2cd;
+  --ok: #11d3ff;
+  --warn: #f2c319;
+  --alert: #f69d2d;
+  --critical: #ff3f96;
+}
+
+* { box-sizing: border-box; }
+
+body {
+  margin: 0;
+  font-family: "Segoe UI", Tahoma, sans-serif;
+  background: radial-gradient(circle at top, #082261 0%, var(--bg) 40%);
+  color: var(--text);
+}
+
+.container {
+  width: min(1280px, 96%);
+  margin: 1.5rem auto;
+}
+
+h1, h2, h3, p { margin: 0; }
+
+.topbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 1rem;
+}
+
+.topbar h1 { color: #ffbf45; font-size: 3rem; }
+.topbar p { color: var(--muted); margin-top: .3rem; }
+
+.panel {
+  background: linear-gradient(180deg, #0a2464 0%, #05174b 100%);
+  border: 1px solid var(--stroke);
+  border-radius: 14px;
+  padding: .8rem;
+  margin-bottom: .7rem;
+}
+
+.controls-row,
+.filters,
+.panel-header,
+.summary-grid {
+  display: grid;
+  gap: .6rem;
+}
+
+.controls-row {
+  grid-template-columns: 1.5fr repeat(3, auto);
+  align-items: center;
+}
+
+.filters {
+  margin-top: .6rem;
+  grid-template-columns: repeat(4, 1fr);
+}
+
+input, select, .btn {
+  border-radius: 24px;
+  border: 1px solid #2f66ca;
+  background: #13337b;
+  color: var(--text);
+  padding: .62rem .95rem;
+  font-weight: 600;
+}
+
+.btn { cursor: pointer; }
+
+.btn-primary { background: #ffba2f; color: #0f2050; border-color: #ffba2f; }
+.btn-secondary { background: #3159b6; }
+.btn-danger { background: #8e1856; border-color: #bd2b72; }
+.btn-outline { background: #1d3b86; }
+
+#statusText { margin-top: .5rem; color: var(--muted); }
+
+h2 { font-size: 3rem; margin-bottom: .45rem; }
+
+.summary-grid.top { grid-template-columns: repeat(3, 1fr); margin-bottom: .55rem; }
+.summary-grid.bottom { grid-template-columns: repeat(4, 1fr); }
+
+.card {
+  border: 1px solid #2764ce;
+  border-radius: 12px;
+  padding: .6rem;
+  background: #021b56;
+  display: flex;
+  flex-direction: column;
+  gap: .35rem;
+}
+
+.card strong { font-size: 3.1rem; line-height: 1; }
+.card span { color: var(--muted); font-size: 1.85rem; }
+.status h3 { font-size: 3rem; }
+
+.ok { border-color: var(--ok); }
+.warn { border-color: var(--warn); }
+.alert { border-color: var(--alert); }
+.critical { border-color: var(--critical); }
+
+.chart {
+  border: 1px solid #2965cb;
+  border-radius: 12px;
+  min-height: 250px;
+  padding: 1rem;
+  display: flex;
+  align-items: flex-end;
+  gap: .8rem;
+  overflow-x: auto;
+}
+
+.bar {
+  min-width: 48px;
+  display: grid;
+  gap: .3rem;
+  justify-items: center;
+}
+
+.bar-inner {
+  width: 100%;
+  border-radius: 8px 8px 0 0;
+  background: linear-gradient(#ff6a9c, #f2517f);
+}
+
+.bar label { color: var(--muted); font-size: .75rem; }
+
+.table-wrap { overflow-x: auto; }
+
+table { width: 100%; border-collapse: collapse; font-size: 1.7rem; }
+th, td { text-align: left; padding: .52rem .45rem; border-bottom: 1px solid #12489b; }
+th { color: #ffbf45; }
+
+.badge {
+  border-radius: 999px;
+  font-size: 1.45rem;
+  padding: .2rem .55rem;
+  display: inline-block;
+  font-weight: 700;
+}
+
+.badge.ok { background: #134976; color: #63e4ff; }
+.badge.warn { background: #5a4a08; color: #ffe469; }
+.badge.alert { background: #613606; color: #ffc071; }
+.badge.critical { background: #70184b; color: #ff7eb4; }
+
+@media (max-width: 960px) {
+  .controls-row,
+  .filters,
+  .summary-grid.top,
+  .summary-grid.bottom {
+    grid-template-columns: 1fr;
+  }
+
+  .topbar h1 { font-size: 2rem; }
+  h2 { font-size: 1.8rem; }
+}


### PR DESCRIPTION
### Motivation
- Fornecer um portal web estático em tema escuro para monitoramento de contratos e alertas de remessas com filtros e visualizações.
- Entregar uma versão pronta para publicar em GitHub Pages que permita carregar CSV/JSON, visualizar resumos, gráfico de evolução e tabela detalhada.

### Description
- Adicionei `index.html` com a estrutura da interface contendo controles, cards de resumo, gráfico de evolução e tabela paginada. 
- Adicionei `styles.css` com tema escuro, layout responsivo e estilos para botões, cards e badges por severidade. 
- Implementei `script.js` com lógica para carregar CSV/JSON, carregar dados demo, limpar dados, aplicar filtros (ano/mês/período), calcular dias sem remessa, agrupar por mês para o gráfico e paginação da tabela. 
- Incluí `README.md` com instruções de uso e formato esperado do CSV.

### Testing
- Executei `node --check script.js` para validar sintaxe do JavaScript e o comando retornou sucesso. 
- Rodei um servidor local com `python3 -m http.server` e validei a página com `curl -I http://127.0.0.1:4180/index.html`, que retornou `200 OK`. 
- Usei um script Playwright para abrir a página, acionar o botão de demo e gerar um screenshot (`artifacts/remessas-portal.png`), e a captura foi produzida com sucesso.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b7800b7bc8328987f6df317af5994)